### PR TITLE
use Capture::Tiny to capture cpanm output

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ requires 'Try::Tiny', 0.09;
 requires 'parent', 0.223;
 requires 'local::lib', 1.008;
 requires 'Exception::Class', 1.32;
+requires 'Capture::Tiny';
 
 # MYMETA support
 requires 'App::cpanminus', 1.5000;

--- a/lib/Carton.pm
+++ b/lib/Carton.pm
@@ -10,6 +10,7 @@ use Config qw(%Config);
 use Carton::Util;
 use CPAN::Meta;
 use File::Path;
+use Capture::Tiny 'capture';
 
 use constant CARTON_LOCK_VERSION => '0.9';
 our $DefaultMirror = 'http://cpan.metacpan.org/';
@@ -263,13 +264,13 @@ sub build_deps {
 sub run_cpanm_output {
     my($self, @args) = @_;
 
-    my $pid = open(my $kid, "-|"); # XXX portability
-    if ($pid) {
-        return <$kid>;
-    } else {
+    my $deps = capture {
         local $ENV{PERL_CPANM_OPT};
-        exec "cpanm", "--quiet", "-L", $self->{path}, @args;
-    }
+        system "cpanm", "--quiet", "-L", $self->{path}, @args;
+    };
+    my @deps = split $/, $deps;
+
+    return @deps;
 }
 
 sub run_cpanm {


### PR DESCRIPTION
This might be a possible way to make capturing the cpanm output completely portable. So far it works fine on my machine.
