### PR TITLE
force the newlines in carton.lock to be \n

### DIFF
--- a/lib/Carton/Util.pm
+++ b/lib/Carton/Util.pm
@@ -13,6 +13,7 @@ sub dump_json {
     my($data, $file) = @_;
 
     open my $fh, ">", $file or die "$file: $!";
+    binmode $fh;
     print $fh to_json($data);
 }
 


### PR DESCRIPTION
The json dump function created the lock file with system newlines, leading to the entirety of it being changed on updates across different OSes, which is terrible for source control. This change forces it to write \ns.
