### PR TITLE
support specify multiple mirror

### DIFF
--- a/lib/Carton.pm
+++ b/lib/Carton.pm
@@ -97,11 +97,17 @@ sub install_conservative {
 
     my $mirror = $self->{mirror} || $DefaultMirror;
 
+    my $is_default_mirror = 0;
+    if ( !ref $mirror ) {
+        $is_default_mirror = $mirror eq $DefaultMirror ? 1 : 0;
+        $mirror = [split /,/, $mirror];
+    }
+
     $self->run_cpanm(
-        "--mirror", $mirror,
+        (map { ("--mirror", $_) } @{$mirror}),
         "--mirror", "http://backpan.perl.org/", # fallback
         "--skip-satisfied",
-        ( $mirror ne $DefaultMirror ? "--mirror-only" : () ),
+        ( $is_default_mirror ? () : "--mirror-only" ),
         ( $self->lock ? ("--mirror-index", $self->{mirror_file}) : () ),
         ( $cascade ? "--cascade-search" : () ),
         @$modules,

--- a/xt/cli/mirror_multi.t
+++ b/xt/cli/mirror_multi.t
@@ -1,0 +1,34 @@
+use strict;
+use Test::More;
+use xt::CLI;
+use Cwd;
+
+my $cwd = Cwd::cwd();
+
+{
+    # split string
+    my $app = cli();
+
+    $app->carton->{mirror} = "$cwd/xt/mirror,http://cpan.metacpan.org/";
+    $app->run("install", "PSGI");
+
+    $app->run("list");
+    like $app->output, qr/^PSGI-/;
+}
+
+{
+    # ARRAY ref
+    my $app = cli();
+
+    $app->carton->{mirror} = ["$cwd/xt/mirror", "http://cpan.metacpan.org/"];
+    $app->run("install", "PSGI");
+
+    $app->run("list");
+    like $app->output, qr/^PSGI-/;
+}
+
+
+done_testing;
+
+
+


### PR DESCRIPTION
I use OrePAN repository and it only includes original modules.
I wanna install CPAN modules from other cpan mirror.

SYNOPSYS

<pre>
PERL_CARTON_MIRROR=/path/to/orepan,http://cpan.metacpan.org/ carton install
</pre>
