### PR TITLE
bundle support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ requires 'Module::Build', 0.38;
 requires 'CPAN::Meta', 2.112;
 
 # bundle DarkPAN support
+requires 'File::chdir';
 requires 'Dist::Metadata';
 requires 'IO::Compress::Gzip';
 


### PR DESCRIPTION
- support `carton bundle`
  - download by `cpanm --scandeps --format=dists --save-dists=local/cache`
  - use Dist::Metadata and IO::Compress::Gzip for creating DarkPAN index
- support `carton install --cached` using bundled DarkPAN
- do not use CPAN::Meta::load_file when MYMETA.json is not exist
