### PR TITLE
Add `carton bundle --locked` option not to rebuild carton.lock

### DIFF
--- a/lib/Carton.pm
+++ b/lib/Carton.pm
@@ -97,7 +97,7 @@ sub dedupe_modules {
 }
 
 sub download_conservative {
-    my($self, $modules, $dir, $cascade) = @_;
+    my($self, $modules, $dir, $cascade, $download) = @_;
 
     $modules = $self->dedupe_modules($modules);
 
@@ -109,6 +109,7 @@ sub download_conservative {
         "--mirror", $mirror,
         "--mirror", "http://backpan.perl.org/", # fallback
         "--no-skip-satisfied",
+        ( $download ? ("--mirror-index", $self->{mirror_file}) : () ),
         ( $mirror ne $DefaultMirror ? "--mirror-only" : () ),
         ( $cascade ? "--cascade-search" : () ),
         "--scandeps",
@@ -116,10 +117,12 @@ sub download_conservative {
         @$modules,
     );
 
-    # write 02packages using local installations
-    my %installs = $self->find_installs;
-    my $index = $self->build_index(\%installs);
-    $self->build_mirror_file($index, $self->{mirror_file});
+    unless ($download) {
+        # write 02packages using local installations
+        my %installs = $self->find_installs;
+        my $index = $self->build_index(\%installs);
+        $self->build_mirror_file($index, $self->{mirror_file});
+    }
 }
 
 sub install_conservative {


### PR DESCRIPTION
Sometimes I want to bundle tarballs of depending modules with `carton bundle` but do not want to update carton.lock. This PR adds `--locked` option to bundle so that
- do not update carton.lock,
- do not re-scan dependency of each module, use carton.lock's information instead.

In addition (not included in this PR), I am thinking of calling cpanm with `--download` option (https://github.com/motemen/carton/tree/bundle-locked-download), if cpanm --download is implemented (https://github.com/miyagawa/cpanminus/pull/118 or https://github.com/motemen/cpanminus/tree/download). If so, bundling speed could be tuned to be faster.

In japanese: http://subtech.g.hatena.ne.jp/motemen/20121005/1349439476
