### PR TITLE
add --with-test option when carton install

### DIFF
--- a/lib/Carton.pm
+++ b/lib/Carton.pm
@@ -301,7 +301,7 @@ sub run_cpanm_output {
 sub run_cpanm {
     my($self, @args) = @_;
     local $ENV{PERL_CPANM_OPT};
-    !system "cpanm", "--quiet", "-L", $self->{path}, "--notest", @args;
+    !system "cpanm", "--quiet", "-L", $self->{path}, ($self->{with_test} ? () : "--notest"), @args;
 }
 
 sub update_lock_file {

--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -159,11 +159,13 @@ sub cmd_bundle {
 sub cmd_install {
     my($self, @args) = @_;
 
+    my $with_test;
     $self->parse_options(
         \@args,
         "p|path=s"    => sub { $self->carton->{path} = $_[1] },
         "deployment!" => \$self->{deployment},
         "cached!"     => \$self->{use_local_mirror},
+        "with-test!"  => \$with_test,
     );
 
     my $lock = $self->find_lock;
@@ -173,6 +175,7 @@ sub cmd_install {
         lock => $lock,
         mirror_file => $self->mirror_file, # $lock object?
         ( $self->{use_local_mirror} && -d $local_mirror ? (mirror => $local_mirror) : () ),
+        with_test => $with_test,
     );
 
     my $cpanfile = $self->has_cpanfile;


### PR DESCRIPTION
Hello,
I want a option to run tests when installing modules.
This pull-request adds `--with-test` option when `carton install`.

Thank you.
