### PR TITLE
Added support for specifying the environment (phase) to be used when looking dependencies from cpanfile

### DIFF
--- a/lib/Carton.pm
+++ b/lib/Carton.pm
@@ -52,12 +52,11 @@ sub list_dependencies {
 
     my $reqs = CPAN::Meta::Requirements->new;
 
-    print STDERR "\n\n\n$self->{env}\n\n\n";
     my @phases = qw(configure build runtime);
-    push @phases, $self->{env} if $self->{env};
+    push @phases, $self->{build_environment} if $self->{build_environment};
 
     $reqs->add_requirements($prereq->requirements_for($_, 'requires'))
-        for @phases;
+      for @phases;
 
     my $hash = $reqs->as_string_hash;
     return map "$_~$hash->{$_}", keys %$hash; # TODO refactor to not rely on string representation

--- a/lib/Carton.pod
+++ b/lib/Carton.pod
@@ -81,6 +81,15 @@ This will look at the I<carton.lock> and install the exact same
 versions of the dependencies into I<local>, and now your application
 is ready to run.
 
+=head2 Build environment
+
+Using cpanfile you can specify different build environments to include
+additional dependencies such as author tools or test libraries. You can
+install those additional dependencies running the following command:
+
+  # Install "test" dependencies
+  > carton install --with test 
+
 =head2 Bundling modules
 
 carton can bundle all the tarballs for your dependencies into a

--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -161,7 +161,7 @@ sub cmd_install {
 
     $self->parse_options(
         \@args,
-        "e|env=s"     => sub { $self->carton->{env} = $_[1] },
+        "with=s"      => sub { $self->carton->{build_environment} = $_[1] },
         "p|path=s"    => sub { $self->carton->{path} = $_[1] },
         "deployment!" => \$self->{deployment},
         "cached!"     => \$self->{use_local_mirror},


### PR DESCRIPTION
Hi,

My little commit add the ability to provide "--env" as part of install to then pass it to cpanfile and depending on that install other modules
