### PR TITLE
Implement Carton::Setup (was: PERL_CARTON_EXEC)

### DIFF
--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -313,7 +313,7 @@ sub cmd_exec {
     $self->parse_options(\@args, 'I=s@', \@include, "system", \$system);
 
     local %ENV = %ENV;
-    Carton::Setup::setup_env(
+    Carton::Setup->setup_env(
         path => $self->carton->{path},
         includes => \@include,
     );

--- a/lib/Carton/Setup.pm
+++ b/lib/Carton/Setup.pm
@@ -7,18 +7,21 @@ sub import {
     my %args = @_;
 
     if (! exists $args{setup}) {
+        # If unspecified, run automatic setup
         $args{setup} = 1;
     }
 
-    if (! delete $args{setup}) {
-        return;
-    }
-
-    setup(%args);
+    $class->setup(%args);
 }
 
 sub setup {
-    my $params = setup_params(@_);
+    my $class = shift;
+    my %args = @_;
+
+    if (! $args{setup}) {
+        return;
+    }
+    my $params = $class->setup_params(%args);
 
     # ENV{PATH} should be set
     $ENV{PATH} = $params->{path};
@@ -29,19 +32,20 @@ sub setup {
     lib::core::only->import;
 
     # @INC, not ENV{PERL5LIB} or ENV{PERL5OPT} should be set
-    foreach my $lib (@{ $params->{includes} }) {
-        lib->import($lib);
-    }
+    my $includes = $params->{includes};
+    lib->import(@$includes);
 }
 
 sub setup_env {
     my $params = setup_params(@_);
 
-    $ENV{PERL5OPT} = "-Mlib::core::only -Mlib=$params->{includes}";
+    my $libs = join ",", @{$params->{includes} || []};
+    $ENV{PERL5OPT} = "-Mlib::core::only -Mlib=$libs";
     $ENV{PATH} = $params->{path};
 }
 
 sub setup_params {
+    my $class = shift;
     my %args = @_;
 
     my $carton = Carton->new;
@@ -53,7 +57,7 @@ sub setup_params {
         path     => "$path/bin:$ENV{PATH}",
     );
 
-    return \%params;;
+    return \%params;
 }
 
 1;
@@ -78,7 +82,7 @@ application work as expected.
 
 All you need to do is to "use" this module in your script:
 
-    use Carton::Setup
+    use Carton::Setup;
 
 If you want to specify additional paths to be included in @INC, use the
 inclues option:
@@ -91,5 +95,74 @@ You can disable automatic setup (but if you're doing this, you're either
 the author of carton, or you are doing something completely wrong):
 
     use Carto::Setup setup => 0;
+
+=head1 API
+
+Please note that regular Carton users DO NOT, and SHOULD NOT need to use 
+this API. They are described here for clarification, but they are meant to
+be used internally in Carton. These are subject to change.
+
+=head2 $class->setup(%args)
+
+Sets up I<the current process> so module include paths and executable paths are
+correctly aligned.
+
+If given the argument C<setup>, it controls if the actual setup should be
+executed or not. This is used for Carton-internal code to load Carton::Setup
+but to skip automatic setup:
+
+    use Carton::Setup setup => 0;
+
+The rest of arguments are internally sent to C<setup_params()>. Please see C<setup_params()> for details.
+
+=head2 $class->setup_env(%args);
+
+Sets up I<environment variables> so processes spawned from Carton can inherit
+the necessary settings.
+
+Note that this I<overwrites> portions of %ENV, so if you want to localize
+its effects, you would need to localize %ENV before calling this function:
+
+    local %ENV;
+    $class->setup_env(%args);
+
+Arguments are internally sent to C<setup_params()>. Please see C<setup_params()> for details.
+
+=head2 $class->setup_params(%args)
+
+Creates a hashref with information to setup the environment, based on C<%args>.
+
+Arguments may be:
+
+=over 4
+
+=item path
+
+Specifies the location where Carton files are installed. By default this is
+"local"
+
+=item includes
+
+Specifies I<extra> directories to look modules for. Note that you do not need
+to specify the location inside C<path> above (because it's automatically 
+setup)
+
+=back
+
+=head1 CAVEATS
+
+If you're using Carton::Setup in your scripts, you SHOULD specify Carton
+itself in your cpanfile, because although this works:
+
+    ./yourscript.pl
+
+But the moment you use 'carton exec', your @INC path will be setup to only
+look at application specific directories, so this will fail to load Carton::Setup:
+
+    carton exec -- ./youscript.pl
+
+To avoid this, make sure to specify Carton in your cpanfile:
+
+    requires 'Carton';
 
 =cut


### PR DESCRIPTION
Scenario: You have a legacy app that is now carton-ized. You have a bunch of scripts that don't use carton, and you can't expect people in your teamto explicitly call "carton exec -- script.pl". So you want to re-execute these scripts via carton and set the right paths when somebody casually does "./bin/foo.pl".

This change allows sets $ENV{PERL_CARTON_EXEC} variable to true, so called scripts can detect if it has been dispatched via carton or not.
