### PR TITLE
fix docs about carton install --cached

### DIFF
--- a/lib/Carton/Doc/Install.pod
+++ b/lib/Carton/Doc/Install.pod
@@ -52,7 +52,7 @@ dependencies.
 
 Force the deployment mode. See L</"DEPLOYMENT MODE"> above.
 
-=item --cache
+=item --cached
 
 Locate distribution tarballs in C<vendor/cache> rather than fetching
 them from CPAN mirrors. This requires you to run C<carton bundle>


### PR DESCRIPTION
The docs about carton install said that it has `--cache` options, but has `--cached`
