### PR TITLE
Updated README for Carton::Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ will install modules using this local cache. Combined with
 CPAN Meta DB or downloading files from CPAN mirrors upon deployment
 time.
 
+Additionally, if you have installed [Carton::Packer](http://search.cpan.org/perldoc?Carton::Packer),
+carton will create a standalone executable into the _vendor/bin_ directory
+called *carton*.  This is especially useful if you are unable to install carton before deployment.
+
 # PERL VERSIONS
 
 When you take a snapshot in one perl version and deploy on another


### PR DESCRIPTION
Updated the README file to include a description of Carton::Packer for creating a standalone Carton executable.  You had discussed it in the screencast from your blog, but it was not in the documentation and it required I install Carton::Packer separately.
