### PR TITLE
can select cpanm "-l" or "-L"

### DIFF
--- a/lib/Carton/Builder.pm
+++ b/lib/Carton/Builder.pm
@@ -9,6 +9,7 @@ has cascade => (is => 'rw', default => sub { 1 });
 has without => (is => 'rw', default => sub { [] });
 has cpanfile => (is => 'rw');
 has fatscript => (is => 'lazy');
+has skip_installed => (is => 'rw', default => sub { 0 });
 
 sub effective_mirrors {
     my $self = shift;
@@ -49,7 +50,7 @@ sub install {
     my($self, $path) = @_;
 
     $self->run_cpanm(
-        "-L", $path,
+        ( $self->skip_installed ? "-l" : "-L" ), $path,
         (map { ("--mirror", $_->url) } $self->effective_mirrors),
         ( $self->index ? ("--mirror-index", $self->index) : () ),
         ( $self->cascade ? "--cascade-search" : () ),
@@ -79,7 +80,7 @@ sub update {
     my($self, $path, @modules) = @_;
 
     $self->run_cpanm(
-        "-L", $path,
+        ( $self->skip_installed ? "-l" : "-L" ), $path,
         (map { ("--mirror", $_->url) } $self->effective_mirrors),
         ( $self->custom_mirror ? "--mirror-only" : () ),
         "--save-dists", "$path/cache",

--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -169,11 +169,12 @@ sub cmd_install {
 
     $self->parse_options(
         \@args,
-        "p|path=s"    => \$install_path,
-        "cpanfile=s"  => \$cpanfile_path,
-        "without=s"   => sub { push @without, split /,/, $_[1] },
-        "deployment!" => \my $deployment,
-        "cached!"     => \my $cached,
+        "p|path=s"        => \$install_path,
+        "cpanfile=s"      => \$cpanfile_path,
+        "without=s"       => sub { push @without, split /,/, $_[1] },
+        "deployment!"     => \my $deployment,
+        "cached!"         => \my $cached,
+        "skip-installed!" => \my $skip_installed,
     );
 
     my $env = Carton::Environment->build($cpanfile_path, $install_path);
@@ -188,6 +189,7 @@ sub cmd_install {
         mirror  => $self->mirror,
         without => \@without,
         cpanfile => $env->cpanfile,
+        skip_installed => $skip_installed,
     );
 
     # TODO: --without with no .lock won't fetch the groups, resulting in insufficient requirements


### PR DESCRIPTION
allow following option:

```
carton install --skip-installed
```

it selects cpanm options `-l | --local-lib` and `-L | --local-lib-contained`.
(`-l` can skip already installed modules)
