### PR TITLE
Try to fix mixed console output on Windows

### DIFF
--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -19,7 +19,7 @@ use Carton::Error;
 
 use constant { SUCCESS => 0, INFO => 1, WARN => 2, ERROR => 3 };
 
-our $UseSystem = 0; # 1 for unit testing
+our $UseSystem = ($^O eq 'MSWin32'); # 1 for unit testing, and for Windows
 
 has verbose => (is => 'rw');
 has carton  => (is => 'lazy');


### PR DESCRIPTION
When executing carton exec COMMAND on Windows, the command returns to
the command prompt while it's running. Using system instead of exec on Windows makes carton behave correctly