### PR TITLE
Fatal warnings during system() or exec() call

### DIFF
--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -387,6 +387,7 @@ sub cmd_exec {
     local $ENV{PERL5LIB} = "$path/lib/perl5";
     local $ENV{PATH} = "$path/bin:$ENV{PATH}";
 
+    use warnings FATAL => 'all';
     $UseSystem ? system(@args) : exec(@args);
 }
 


### PR DESCRIPTION
In 082f6e75baabd21c1af9c5f06b8e91d52d643a0b the warnings were removed from CLI.pm. As a result we no longer get any output when exec fails to find anything to run.

Additionally we do not get a failure status code on command not found.

I'm not sure what the semantics are expected to be, but this doesn't work right.

This PR introduces fatal warnings, which makes an exception occur if the command cannot be found.

Please note, this causes exit status 2, not exit 127 which is the defacto status code for 'command not found', but 2 is a lot better than 0