### PR TITLE
Don't die if no .meta directories are present during fatpack

### DIFF
--- a/lib/Carton/Packer.pm
+++ b/lib/Carton/Packer.pm
@@ -84,7 +84,9 @@ sub installed_meta {
         }
     };
 
-    File::Find::find({ wanted => $finder, no_chdir => 1 }, grep -d, map "$_/.meta", @INC);
+    my @meta_dirs = grep -d, map "$_/.meta", @INC;
+    File::Find::find({ wanted => $finder, no_chdir => 1 }, @meta_dirs)
+        if @meta_dirs;
 
     # return the latest version
     @meta = sort { version->new($b->version) cmp version->new($a->version) } @meta;


### PR DESCRIPTION
Before this change, the following error message was emitted if no `.meta` directories were present:
```
invalid top directory at /usr/share/perl5/File/Find.pm line 472.
```

After this change, the following error message was emitted instead.  I think this is more informative.
```
Couldn't find install metadata for Carton at /usr/local/share/perl5/Carton/Packer.pm line 61.
```

This follows on from issue https://github.com/miyagawa/cpanminus/issues/457.