### PR TITLE
FAQ updates for Perlbrew

### DIFF
--- a/lib/Carton/Doc/FAQ.pod
+++ b/lib/Carton/Doc/FAQ.pod
@@ -101,7 +101,7 @@ I<myapp>. Install L<Carton> and all of its dependencies to the
 I<myapp> local::lib path. Then run C<carton install> like you
 normally do.
 
-Becuase I<devel> and I<myapp> are isolated, the modules you installed
+Because I<devel> and I<myapp> are isolated, the modules you installed
 into I<devel> doesn't affect the process when carton builds the
 dependency tree for your new project at all. This could often be
 critical when you have a conditional dependency in your tree, like

--- a/lib/Carton/Doc/FAQ.pod
+++ b/lib/Carton/Doc/FAQ.pod
@@ -118,3 +118,42 @@ that is hard-coded at the top of the C<carton> script.
 
 Carton will do the right thing when calling C<cpanm> to install your dependencies,
 running it under the same C<perl> as Carton is running on.
+
+=head2 Using C<< perl -S carton install >> is ugly, any permanent fix?
+
+The issue is most likelly caused by a inital bad install of C<cpanm>,
+that ended up with a shebang line pointed to the system perl.
+
+To fix:
+
+=over 4
+
+=item Make sure you perlbrew-installed cpanm is not using system perl
+
+Run this: C<< head -1 "$PERLBREW_ROOT/bin/cpanm" >>
+
+If the output is not C<< #!/usr/bin/env perl >>, then you have
+a bad C<cpanm> installed.
+
+Run C<< perlbrew install-cpanm >> to fix it. Re-run the previous
+command to make sure it was fixed.
+
+=item Re-install cpanm on your perlbrew environment
+
+Switch to the perlbrew environment you plan on using and force
+install C<cpanm>. Use C<< "$PERLBREW_ROOT/bin/cpanm -f App::cpanminus >>
+to make sure you use the newly fixed C<cpanm> from perlbrew.
+
+This will make sure that your new environment has a C<cpanm> that will
+use the correct C<perl> for that environment.
+
+=item Re-install Carton on you perlbrew environment
+
+Run C<< cpanm -f Carton >>. This will force-install Carton,
+and because your C<cpanm> is now using the correct C<perl>,
+the same will happen with C<carton>.
+
+=back
+
+After this process, your C<< carton install >> will use the
+correct C<perl>.

--- a/lib/Carton/Doc/FAQ.pod
+++ b/lib/Carton/Doc/FAQ.pod
@@ -109,4 +109,12 @@ L<Any::Moose>.
 
 =back
 
+=head2 I'm using perlbrew, but C<< carton install >> uses system perl, how to fix?
 
+Instead of C<< carton install >>, use C<< perl `which carton` install >>.
+
+This will force the use of the C<perl> from your PATH, and not the C</usr/bin/perl>
+that is hard-coded at the top of the C<carton> script.
+
+Carton will do the right thing when calling C<cpanm> to install your dependencies,
+running it under the same C<perl> as Carton is running on.

--- a/lib/Carton/Doc/FAQ.pod
+++ b/lib/Carton/Doc/FAQ.pod
@@ -111,7 +111,7 @@ L<Any::Moose>.
 
 =head2 I'm using perlbrew, but C<< carton install >> uses system perl, how to fix?
 
-Instead of C<< carton install >>, use C<< perl `which carton` install >>.
+Instead of C<< carton install >>, use C<< perl -S carton install >>.
 
 This will force the use of the C<perl> from your PATH, and not the C</usr/bin/perl>
 that is hard-coded at the top of the C<carton> script.


### PR DESCRIPTION
Small note about how to work-around carton install issues with perlbrew.

Although some of them might be caused by a broken initial setup of cpanm, that forced system perl on it, it might be useful to others how to workaround such setups.