### PR TITLE
add env command, to output environment to stdout for use by shell

### DIFF
--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -402,4 +402,16 @@ sub cmd_exec {
     }
 }
 
+sub cmd_env {
+
+    my $env = Carton::Environment->build;
+    $env->snapshot->load;
+    # PERL5LIB takes care of arch
+    my $path = $env->install_path;
+    local $ENV{PERL5LIB} = "$path/lib/perl5";
+    local $ENV{PATH} = "$path/bin:$ENV{PATH}";
+
+    print "export PERL5LIB='$ENV{PERL5LIB}'; export PATH='$ENV{PATH}';"
+}
+
 1;

--- a/lib/Carton/Doc/Env.pod
+++ b/lib/Carton/Doc/Env.pod
@@ -1,0 +1,18 @@
+=head1 NAME
+
+Carton::Doc::Env - print carton environment variables to stdout
+
+=head1 SYNOPSIS
+
+  carton env
+
+=head1 DESCRIPTION
+
+This command outputs the environment variables necessary to setup the
+carton local environment to stdout, as bash/zsh sourceable statements.
+For example,
+
+  eval $(carton env)
+
+will set the current shell enviroment so that it looks liek the carton
+local environment.

--- a/xt/cli/env.t
+++ b/xt/cli/env.t
@@ -1,0 +1,30 @@
+use strict;
+use Test::More;
+use xt::CLI;
+use Capture::Tiny qw( capture );
+
+subtest 'carton env', sub {
+
+    my $app = cli();
+    $app->write_cpanfile( '' );
+    $app->run( "install" );
+
+    my $stdout;
+
+    # use the exec command to get the expected values of the
+    # environment variables.  Note that $^X is used here instead
+    # of "perl", as "perl" may be a proxy (e.g. plenv) and may
+    # change the environment in such a way that it's difficult
+    # to use it as a fiducial value
+    my %exp = map {
+        $app->run( "exec", $^X, "-le", "print \$ENV{$_}" );
+        chomp( my $stdout = $app->stdout );
+        ( $_ => quotemeta $stdout );
+    } qw[ PATH PERL5LIB ];
+
+    $app->run( "env" );
+    like( $app->stdout, qr/export PERL5LIB='$exp{PERL5LIB}';/, "PERL5LIB" );
+    like( $app->stdout, qr/export PATH='$exp{PATH}';/,         "PATH" );
+};
+
+done_testing;


### PR DESCRIPTION
At times it's useful to set up a shell with the `carton` local environment.

`carton exec bash` doesn't always work because it requires that the `bash` startup files pay attention to the existing environment.  This commit adds an `env` command which outputs shell commands to set the `PERL` and `PERL5LIB` environment variables.  It's used thusly:

`eval $(carton env)`

