### PR TITLE
Ensure paths on Windows use backslash and semicolon as path separator…

### DIFF
--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -391,8 +391,9 @@ sub cmd_exec {
 
     # PERL5LIB takes care of arch
     my $path = $env->install_path;
-    local $ENV{PERL5LIB} = "$path/lib/perl5";
-    local $ENV{PATH} = "$path/bin:$ENV{PATH}";
+    my $psep = ($^O eq 'MSWin32' ? ';' : ':');
+    local $ENV{PERL5LIB} = slashify("$path/lib/perl5");
+    local $ENV{PATH} = slashify("$path/bin$psep$ENV{PATH}");
 
     if ($UseSystem) {
         system @args;
@@ -400,6 +401,13 @@ sub cmd_exec {
         exec @args;
         exit 127; # command not found
     }
+}
+
+sub slashify {
+    my $p = shift;
+    my $sep = shift || ($^O eq 'MSWin32' ? '\\' : '/');
+    $p =~ s#[/\\]+#$sep#g;
+    return $p;
 }
 
 1;


### PR DESCRIPTION
… when setting PATH/PERL5LIB before run/exec.

The change is not critical for PERL5LIB, but the PATH won't work otherwise.