### PR TITLE
Add lazy loaded Menlo::Index::Mirror to the fatpack required modules

### DIFF
--- a/lib/Carton/Packer.pm
+++ b/lib/Carton/Packer.pm
@@ -63,7 +63,10 @@ sub required_modules {
         $requirements{$_} = 1 for $self->required_modules_for($dist);
     }
 
-    [ keys %requirements ];
+    # these modules are needed, but lazy-loaded, so FatPacker wont bundle them by default.
+    my @extra = qw(Menlo::Index::Mirror);
+
+    [ keys %requirements, @extra ];
 }
 
 sub required_modules_for {


### PR DESCRIPTION
This module is lazy loaded by Menlo::CLI::Compat, and as a result,
FatPacker wont pick it up unless we explicity ask it to.

Fixes #237