### PR TITLE
Get version module on snapshot generation

### DIFF
--- a/lib/Carton/Snapshot.pm
+++ b/lib/Carton/Snapshot.pm
@@ -150,11 +150,11 @@ sub find_installs {
     my $accepts = sub {
         my $module = shift;
 
-        return 0 unless $reqs->accepts_module($module->{name}, $module->{provides}{$module->{name}}{version});
+        return 0 unless $reqs->accepts_module($module->{name}, $module->{provides}{$module->{name}}{version}||$module->{version});
 
         if (my $exist = $installs{$module->{name}}) {
-            my $old_ver = version::->new($exist->{provides}{$module->{name}}{version});
-            my $new_ver = version::->new($module->{provides}{$module->{name}}{version});
+            my $old_ver = version::->new($exist->{provides}{$module->{name}}{version}||$exist->{version});
+            my $new_ver = version::->new($module->{provides}{$module->{name}}{version}||$module->{version});
             return $new_ver >= $old_ver;
         } else {
             return 1;


### PR DESCRIPTION
Support module with missing a .pm file containing a package matching the dist name