### PR TITLE
Enable the use of cpanfile mirror syntax

### DIFF
--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -215,6 +215,11 @@ sub cmd_install {
 
     if ($cached) {
         $builder->mirror(Carton::Mirror->new($env->vendor_cache));
+    } else {
+        $env->cpanfile->load;
+        if (my $cpanfile_mirror = $env->cpanfile->mirror) {
+            $builder->mirror(Carton::Mirror->new($cpanfile_mirror));
+        }
     }
 
     $builder->install($env->install_path);
@@ -352,6 +357,8 @@ sub cmd_update {
         mirror => $self->mirror,
         cpanfile => $env->cpanfile,
     );
+    $builder->mirror(Carton::Mirror->new($env->cpanfile->mirror))
+        if $env->cpanfile->mirror;
     $builder->update($env->install_path, @modules);
 
     $env->snapshot->find_installs($env->install_path, $env->cpanfile->requirements);

--- a/lib/Carton/CPANfile.pm
+++ b/lib/Carton/CPANfile.pm
@@ -14,6 +14,7 @@ use Class::Tiny {
 
 sub stringify { shift->path->stringify(@_) }
 sub dirname   { shift->path->dirname(@_) }
+sub mirror    { @{shift->_cpanfile->mirrors}[0] }
 sub prereqs   { shift->_cpanfile->prereqs(@_) }
 sub required_modules { shift->requirements->required_modules(@_) }
 sub requirements_for_module { shift->requirements->requirements_for_module(@_) }

--- a/xt/cli/cpanfile.t
+++ b/xt/cli/cpanfile.t
@@ -3,6 +3,15 @@ use Test::More;
 use lib ".";
 use xt::CLI;
 
+subtest 'builder mirrors' => sub {
+    require Carton::Builder;
+    my $builder = Carton::Builder->new(mirror => Carton::Mirror->new('/tmp'));
+    my $mirrors = [ $builder->effective_mirrors ];
+    is @$mirrors, 3, 'three mirrors';
+    is_deeply $mirrors->[0], {url => '/tmp'}, 'custom mirror';
+};
+
+
 subtest 'carton install --cpanfile' => sub {
     my $app = cli();
     $app->write_file('cpanfile.foo', <<EOF);
@@ -40,6 +49,47 @@ EOF
     like $app->stdout, qr/Try-Tiny-0\.11/;
     ok $app->dir->child('cpanfile.foo.snapshot')->exists;
 };
+
+subtest 'mirrors' => sub {
+    my $app = cli();
+    my $cwd = Path::Tiny->cwd;
+
+    local $ENV{PERL_CARTON_CPANFILE} = $app->dir->child('cpanfile.mirror')->absolute;
+
+    $app->write_file('cpanfile.mirror', <<EOF);
+mirror '$cwd/xt/mirror';
+requires 'Hash::MultiValue';
+EOF
+
+    $app->run("install");
+    # diag $app->stdout;
+    # diag $app->stderr;
+
+    $app->run("list");
+    like $app->stdout, qr/^Hash-MultiValue-0\.08/m;
+
+    ok $app->dir->child('cpanfile.mirror.snapshot')->exists;
+};
+
+subtest 'mirror / dist syntax for requires' => sub {
+    my $app = cli();
+    my $cwd = Path::Tiny->cwd;
+
+    local $ENV{PERL_CARTON_CPANFILE} = $app->dir->child('cpanfile.mirror')->absolute;
+
+    $app->write_file('cpanfile.mirror', <<EOF);
+requires 'Hash::MultiValue',
+    dist => 'MIYAGAWA/Hash-MultiValue-0.08.tar.gz',
+    mirror => 'file://$cwd/xt/mirror';
+EOF
+
+    $app->run("install");
+    $app->run("list");
+    like $app->stdout, qr/^Hash-MultiValue-0\.08/m;
+
+    ok $app->dir->child('cpanfile.mirror.snapshot')->exists;
+};
+
 
 done_testing;
 

--- a/xt/cli/update.t
+++ b/xt/cli/update.t
@@ -75,5 +75,41 @@ EOF
     }
 };
 
+subtest 'carton update from mirror' => sub {
+    my $app = cli();
+    my $cwd = Path::Tiny->cwd;
+
+    local $ENV{PERL_CARTON_CPANFILE} = $app->dir->child('cpanfile.mirror')->absolute;
+
+    $app->write_file('cpanfile.mirror', <<EOF);
+mirror '$cwd/xt/mirror';
+requires 'Hash::MultiValue';
+EOF
+
+    $app->run("install");
+    $app->run("update");
+    # diag $app->stdout;
+    # diag $app->stderr;
+
+    like $app->stdout, qr/^Hash::MultiValue is up to date\. \(0\.08\)/m;
+
+    ok $app->dir->child('cpanfile.mirror.snapshot')->exists;
+
+    # Again, without mirror - will update to latest version
+    $app->write_file('cpanfile.mirror', <<EOF);
+requires 'Hash::MultiValue';
+EOF
+
+    $app->run("update");
+    # installed...
+    like $app->stdout,
+      qr/Successfully installed Hash-MultiValue-[\.0-9]+ \(upgraded from 0\.08\)$/m;
+
+    $app->run("list");
+    like $app->stdout, qr/Hash-MultiValue-[\.0-9]+/, 'present';
+    unlike $app->stdout, qr/Hash-MultiValue-0\.08/, 'not old';
+};
+
+
 done_testing;
 


### PR DESCRIPTION
This adds the
> ability to specify mirrors using cpanfile's mirror syntax.
[comment](https://github.com/perl-carton/carton/pull/199#issuecomment-227908480)

which is in the [DSL](https://github.com/miyagawa/cpanfile/search?q=mirror) also mentioned [here](https://github.com/perl-carton/carton/pull/183#issuecomment-71069553)

`carton` commands `install` and `update` will use the mirror specified in `cpanfile`, as below, in the same way the `PERL_CARTON_MIRROR` environment variable acts, but permits easier source control of the setting.

```perl
mirror "$url";
```

Although there is this alternate syntax which is more specific, it is more verbose and utilising the cpanfile scoped mirror is more attractive.
https://github.com/perl-carton/carton/blob/d7fcb61aaa908e033cf3f66f53fbe9e46743978a/lib/Carton.pm#L100-L103

Travis fails on perl < 5.14 due to requiring `dist: trusty` as per #268