### PR TITLE
Implement carton outdated with App::cpanoutdated

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -23,6 +23,9 @@ requires 'Module::CoreList';
 recommends 'File::pushd';
 recommends 'App::FatPacker', 0.009018;
 
+# for outdated
+recommends 'App::cpanoutdated', 0.32;
+
 on develop => sub {
     requires 'Test::More', 0.90;
     requires 'Test::Requires';

--- a/lib/Carton/CLI.pm
+++ b/lib/Carton/CLI.pm
@@ -402,4 +402,8 @@ sub cmd_exec {
     }
 }
 
+sub cmd_outdated {
+    system "cpan-outdated -Llocal --verbose --exclude-core";
+}
+
 1;

--- a/xt/cli/outdated.t
+++ b/xt/cli/outdated.t
@@ -1,0 +1,48 @@
+use strict;
+use Test::More;
+use lib ".";
+use xt::CLI;
+
+subtest 'carton outdated shows pinned module' => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<EOF);
+requires 'Try::Tiny', '== 0.09';
+EOF
+
+    $app->run("install");
+    $app->run("outdated");
+
+    like $app->stdout, qr/Try::Tiny\s+0.09\s+[0-9.]+\s+/;
+    is $app->stderr, '';
+};
+
+subtest 'carton outdated shows ranged module' => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<EOF);
+requires 'Try::Tiny', '>= 0.09, <= 0.12';
+EOF
+
+    $app->run("install");
+    $app->run("outdated");
+
+    like $app->stdout, qr/Try::Tiny\s+0.12\s+[0-9.]+\s+/;
+    is $app->stderr, '';
+};
+
+subtest 'carton outdated wont show unpinned module' => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<EOF);
+requires 'Try::Tiny', '0.09';
+EOF
+
+    $app->run("install");
+    $app->run("outdated");
+
+    is $app->stdout, '';
+    is $app->stderr, '';
+};
+
+done_testing;


### PR DESCRIPTION
Not sure how good/appropriate this implementation is... per issue #116, I would love to find a way to implement something like "bundle outdated"